### PR TITLE
array: handle leading spaces correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ ClassList.prototype.toggle = function(name){
 
 ClassList.prototype.array = function(){
   var arr = this.el.className.split(re);
-  if ('' === arr[0]) arr.pop();
+  if ('' === arr[0]) arr.shift();
   return arr;
 };
 

--- a/test/classes.js
+++ b/test/classes.js
@@ -82,6 +82,14 @@ describe('classes(el)', function(){
       var ret = classes(el).array();
       assert(0 == ret.length);
     })
+
+    it('should handle leading spaces correctly', function(){
+      el.className = '  foo bar baz';
+      var ret = classes(el).array();
+      assert('foo' == ret[0]);
+      assert('bar' == ret[1]);
+      assert('baz' == ret[2]);
+    })
   })
 
   describe('.has(class)', function(){


### PR DESCRIPTION
use `.shift()` not `.pop()`!

this broke my app in IE haha
