### PR TITLE
Change indexof-component to indexof, so that it can be required

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cross-browser element class list",
   "keywords": ["dom", "html", "classList", "class", "ui"],
   "dependencies": {
-    "indexof-component": "component/indexof#0.0.1"
+    "indexof": "component/indexof#0.0.1"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
classes was not working with browserify without this fix.
