### PR TITLE
add browser field to map indexof -> indexof-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "indexof-component": "component/indexof#0.0.1"
   },
+  "browser": {
+    "indexof": "indexof-component"
+  },
   "component": {
     "scripts": {
       "classes/index.js": "index.js"


### PR DESCRIPTION
Adds support for browserify. Otherwise the module as it exists in npm is
unusable.
