### PR TITLE
Fixing typo in depdencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cross-browser element class list",
   "keywords": ["dom", "html", "classList", "class", "ui"],
   "dependencies": {
-    "indexof-component": "component/indexof#0.0.1"
+    "indexof-component": "0.0.1"
   },
   "browser": {
     "indexof": "indexof-component"


### PR DESCRIPTION
This was stopping it and modules that depend on it from being installable via npm.
