### PR TITLE
Adding support to toggle for the force parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,26 +112,45 @@ ClassList.prototype.removeMatching = function(re){
 };
 
 /**
- * Toggle class `name`.
+ * Toggle class `name`, can force state via `force`.
+ *
+ * For browsers that support classList, but do not support `force` yet,
+ * the mistake will be detected and corrected.
  *
  * @param {String} name
+ * @param {Boolean} force
  * @return {ClassList}
  * @api public
  */
 
-ClassList.prototype.toggle = function(name){
+ClassList.prototype.toggle = function(name, force){
   // classList
   if (this.list) {
-    this.list.toggle(name);
+    if ("undefined" !== typeof force) {
+      if (force !== this.list.toggle(name, force)) {
+        this.list.toggle(name); // toggle again to correct
+      }
+    } else {
+      this.list.toggle(name);
+    }
     return this;
   }
 
   // fallback
-  if (this.has(name)) {
-    this.remove(name);
+  if ("undefined" !== typeof force) {
+    if (!force) {
+      this.remove(name);
+    } else {
+      this.add(name);
+    }
   } else {
-    this.add(name);
+    if (this.has(name)) {
+      this.remove(name);
+    } else {
+      this.add(name);
+    }
   }
+
   return this;
 };
 

--- a/test/classes.js
+++ b/test/classes.js
@@ -51,7 +51,7 @@ describe('classes(el)', function(){
     })
   })
 
-  describe('.toggle(class)', function(){
+  describe('.toggle(class, force)', function(){
     describe('when present', function(){
       it('should remove the class', function(){
         el.className = 'foo bar hidden';
@@ -65,6 +65,34 @@ describe('classes(el)', function(){
         el.className = 'foo bar';
         classes(el).toggle('hidden');
         assert('foo bar hidden' == el.className);
+      })
+    })
+
+    describe('when force is true', function(){
+      it('should add the class', function(){
+        el.className = 'foo bar';
+        classes(el).toggle('hidden', true);
+        assert('foo bar hidden' == el.className);
+      })
+
+      it('should not remove the class', function(){
+        el.className = 'foo bar hidden';
+        classes(el).toggle('hidden', true);
+        assert('foo bar hidden' == el.className);
+      })
+    })
+
+    describe('when force is false', function(){
+      it('should remove the class', function(){
+        el.className = 'foo bar hidden';
+        classes(el).toggle('hidden', false);
+        assert('foo bar' == el.className);
+      })
+
+      it('should not add the class', function(){
+        el.className = 'foo bar';
+        classes(el).toggle('hidden', false);
+        assert('foo bar' == el.className);
       })
     })
   })


### PR DESCRIPTION
I've added support to the `#toggle()` method for the `force` parameter.

This feature is outlined in the [DOMTokenList specification](http://dom.spec.whatwg.org/#dom-domtokenlist-toggle) as well as being a part of other popular libraries like jQuery. I understand this component is _not_ a `classList` polyfill, I'm only mentioning to show that it is implemented elsewhere and has usefulness.

In any case, there is a caveat that I have accounted for. Some browsers support `classList` natively, but not the `force` parameter. (in my tests, this only happened in Safari) In these browsers, the `force` parameter is not acknowledged and a normal toggle takes place. I detect that anomaly and correct it, so this passes in all browsers I've tested:
- Windows (XP and Vista)
  - IE8 and IE9 (respectively)
  - Chrome
  - Safari
- Linux (Ubuntu)
  - Chrome
  - Firefox
