### PR TITLE
index: Improve HTMLElement duck typing

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ module.exports = function(el){
  */
 
 function ClassList(el) {
-  if (!el) throw new Error('A DOM element reference is required');
+  if (!el || !el.nodeType) {
+    throw new Error('A DOM element reference is required');
+  }
   this.el = el;
   this.list = el.classList;
 }


### PR DESCRIPTION
This patch prevents passing a non-element to `ClassList`.
## 

I just spent far too long trying to debug something like this:

``` js
var someView = new SomeView;
classes(someView).add('foobar') // should be classes(someView.el)...
```

we would just fail silently add add:

``` js
someView.className = 'foobar'
```
## 

/cc @yields (again)
