### PR TITLE
Don't use browser alias for component-indexof dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var index = require('indexof');
+var index = require('component-indexof');
 
 /**
  * Whitespace regexp.

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   "dependencies": {
     "component-indexof": "0.0.3"
   },
-  "browser": {
-    "indexof": "component-indexof"
-  },
   "component": {
     "scripts": {
       "classes/index.js": "index.js"


### PR DESCRIPTION
This way, `component-classes` won't break node code/tests when imported.

You might want to change the release date in `History.md`

/cc @TooTallNate 