### PR TITLE
Fixed 'indexof' require issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var index = require('component-indexof');
+var index = require('../component-indexof');
 
 /**
  * Whitespace regexp.


### PR DESCRIPTION
If the root is not used when requiring non-browser-alias requires the below error occurs.
This was introduced in commit [23735595244318d5a190f55484604e04320f080e](https://github.com/component/classes/commit/23735595244318d5a190f55484604e04320f080e)
```
Phantom runner caught error: Error: Failed to require "component-indexof" from "component-classes/index.js"
TRACE:
  http://0.0.0.0:35127/app/dev: 28 (in function "require")
  http://0.0.0.0:35127/app/dev: 177 (in function "localRequire")
  (unknown file): 5 (in function "anonymous")
  http://0.0.0.0:35127/app/dev: 41 (in function "require")
  http://0.0.0.0:35127/app/dev: 177 (in function "localRequire")
  (unknown file): 6 (in function "anonymous")
  http://0.0.0.0:35127/app/dev: 41 (in function "require")
  http://0.0.0.0:35127/app/dev: 177 (in function "localRequire")
  (unknown file): 1 (in function "anonymous")
  http://0.0.0.0:35127/app/dev: 41 (in function "require")
  http://0.0.0.0:35127/app/dev: 177 (in function "localRequire")
  (unknown file): 13 (in function "anonymous")
  http://0.0.0.0:35127/app/dev: 41 (in function "require")
  (unknown file): 63 (anonymous function)
  (unknown file): 481 (anonymous function)
  (unknown file): 152 (anonymous function)
  (unknown file): 193 (anonymous function)
  (unknown file): 482 (anonymous function)
  (unknown file): 97 (in function "onLoad")
  (unknown file): 118 (anonymous function)
```