### PR TITLE
Properly fix `component-indexof` require.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@
  * Module dependencies.
  */
 
-var index = require('component-indexof');
+try {
+  var index = require('indexof');
+} catch (err) {
+  var index = require('component-indexof');
+}
 
 /**
  * Whitespace regexp.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "component-indexof": "0.0.3"
   },
+  "browser": {
+    "indexof": "component-indexof"
+  },
   "component": {
     "scripts": {
       "classes/index.js": "index.js"


### PR DESCRIPTION
Fixing `component` breakage I introduced with #27.

/cc @stephenmathieson @ronkorving
