### PR TITLE
Mitigate Meteor require warning.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@
  * Module dependencies.
  */
 
+var r = require;
 try {
-  var index = require('indexof');
+  var index = r('indexof');
 } catch (err) {
-  var index = require('component-indexof');
+  var index = r('component-indexof');
 }
 
 /**


### PR DESCRIPTION
When `antd` is used in Meteor, this warning shows up:

```
Unable to resolve some modules:

  "indexof" in .../node_modules/component-classes/index.js (web.browser)

If you notice problems related to these missing modules, consider running:

  meteor npm install --save indexof
```

This PR aims to get rid of it.